### PR TITLE
WHF-110: Fix sync when signup with webform and civicrm public form

### DIFF
--- a/CRM/Cti/Hook/Post/SyncParticipant.php
+++ b/CRM/Cti/Hook/Post/SyncParticipant.php
@@ -56,12 +56,16 @@ abstract class CRM_Cti_Hook_Post_SyncParticipant {
     if (empty($ctiSessionID)) {
       return;
     }
-
+    //When the participant is registered via Webform or online registration form
+    //the custom fields will not passed if the fields are not created in a profile / forms
+    //therefore, custom fields will not exist here so $syncStatus should be assigned as empty
     if (!array_key_exists($this->syncStatusField, $this->participant)) {
-      return;
+      $syncStatus = '';
+    }
+    else {
+      $syncStatus = $this->participant[$this->syncStatusField];
     }
 
-    $syncStatus = $this->participant[$this->syncStatusField];
     if ($syncStatus != 'update' && $syncStatus != '') {
       return;
     }


### PR DESCRIPTION
## Overview
This PR is to update the logic that allows the sync with CTI platform to work when the participant is registered via Web form or CiviCRM online event registration form.

## Before
The hook was not processed properly as the custom fields are not existed when the participant is registered online. 

## After
CTI platform will be sync with CiviCRM when participant is registered using Webfrorm or CiviCRM online form. 

## Technical Details
Since the custom fields are not added to the Webform and profile for CiviCRM online form, it results that the custom fields will not be populated in the object, so we check the fields are existed, if not we are assign sync status to empty then  the participant will be synced to CTI platform. 